### PR TITLE
Feature/ab#1071 use geo coordinates for analysis

### DIFF
--- a/persistence/src/main/java/de/starwit/persistence/databackend/entity/AnalyticsJobEntity.java
+++ b/persistence/src/main/java/de/starwit/persistence/databackend/entity/AnalyticsJobEntity.java
@@ -38,6 +38,9 @@ public class AnalyticsJobEntity extends AbstractEntity<Long> {
     @Column(name = "classification")
     private String classification;
 
+    @Column(name = "geo_referenced")
+    private Boolean geoReferenced;
+
     @OneToMany(mappedBy = "analyticsJob", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     private List<PointEntity> geometryPoints;
 
@@ -105,4 +108,11 @@ public class AnalyticsJobEntity extends AbstractEntity<Long> {
         this.classification = classification;
     }
 
+    public Boolean getGeoReferenced() {
+        return geoReferenced;
+    }
+
+    public void setGeoReferenced(Boolean geoReferenced) {
+        this.geoReferenced = geoReferenced;
+    }
 }

--- a/persistence/src/main/java/de/starwit/persistence/databackend/entity/PointEntity.java
+++ b/persistence/src/main/java/de/starwit/persistence/databackend/entity/PointEntity.java
@@ -23,6 +23,12 @@ public class PointEntity extends AbstractEntity<Long> {
     @Column(name = "order_idx")
     private int orderIdx;
 
+    @Column(name = "latitude")
+    private BigDecimal latitude;
+
+    @Column(name = "longitude")
+    private BigDecimal longitude;
+
     @ManyToOne
     @JsonIgnore
     @JoinColumn(name = "analytics_job_id")
@@ -50,6 +56,22 @@ public class PointEntity extends AbstractEntity<Long> {
 
     public void setOrderIdx(int orderIdx) {
         this.orderIdx = orderIdx;
+    }
+
+    public BigDecimal getLongitude() {
+        return longitude;
+    }
+
+    public void setLongitude(BigDecimal longitude) {
+        this.longitude = longitude;
+    }
+
+    public BigDecimal getLatitude() {
+        return latitude;
+    }
+
+    public void setLatitude(BigDecimal latitude) {
+        this.latitude = latitude;
     }
 
     public AnalyticsJobEntity getAnalyticsJob() {

--- a/persistence/src/main/java/de/starwit/persistence/sae/entity/SaeDetectionEntity.java
+++ b/persistence/src/main/java/de/starwit/persistence/sae/entity/SaeDetectionEntity.java
@@ -43,6 +43,12 @@ public class SaeDetectionEntity implements AbstractCaptureEntity {
     @Column(name = "max_y")
     private Double maxY;
 
+    @Column(name = "latitude")
+    private Double latitude;
+
+    @Column(name = "longitude")
+    private Double longitude;
+    
     public Instant getCaptureTs() {
         return captureTs;
     }
@@ -123,6 +129,22 @@ public class SaeDetectionEntity implements AbstractCaptureEntity {
         this.maxY = maxY;
     }
 
+    public Double getLatitude() {
+        return latitude;
+    }
+
+    public void setLatitude(Double latitude) {
+        this.latitude = latitude;
+    }
+
+    public Double getLongitude() {
+        return longitude;
+    }
+
+    public void setLongitude(Double longitude) {
+        this.longitude = longitude;
+    }
+
     public static SaeDetectionEntity from(ResultSet rs) throws SQLException {
         SaeDetectionEntity dto = new SaeDetectionEntity();
         dto.setDetectionId(rs.getLong("DETECTION_ID"));
@@ -135,6 +157,8 @@ public class SaeDetectionEntity implements AbstractCaptureEntity {
         dto.setMinY(rs.getDouble("MIN_Y"));
         dto.setMaxX(rs.getDouble("MAX_X"));
         dto.setMaxY(rs.getDouble("MAX_Y"));
+        dto.setLatitude(rs.getDouble("LATITUDE"));
+        dto.setLongitude(rs.getDouble("LONGITUDE"));
         return dto;
     }
 

--- a/persistence/src/main/java/de/starwit/persistence/sae/repository/SaeRepository.java
+++ b/persistence/src/main/java/de/starwit/persistence/sae/repository/SaeRepository.java
@@ -1,7 +1,6 @@
 package de.starwit.persistence.sae.repository;
 
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;

--- a/persistence/src/main/resources/db/migration/databackend/V1_4__addgeocoordinates.sql
+++ b/persistence/src/main/resources/db/migration/databackend/V1_4__addgeocoordinates.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "point" ADD "longitude" Decimal(22,19);
+ALTER TABLE "point" ADD "latitude" Decimal(22,19);
+
+ALTER TABLE "analytics_job" ADD "geo_referenced" boolean;

--- a/persistence/src/main/resources/db/migration/databackend/V1_4__addgeocoordinnates.sql
+++ b/persistence/src/main/resources/db/migration/databackend/V1_4__addgeocoordinnates.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "point" ADD "longitude" Decimal(20,17);
+ALTER TABLE "point" ADD "latitude" Decimal(20,17);

--- a/persistence/src/main/resources/db/migration/databackend/V1_4__addgeocoordinnates.sql
+++ b/persistence/src/main/resources/db/migration/databackend/V1_4__addgeocoordinnates.sql
@@ -1,2 +1,2 @@
-ALTER TABLE "point" ADD "longitude" Decimal(20,17);
-ALTER TABLE "point" ADD "latitude" Decimal(20,17);
+ALTER TABLE "point" ADD "longitude" Decimal(22,19);
+ALTER TABLE "point" ADD "latitude" Decimal(22,19);

--- a/persistence/src/main/resources/db/migration/databackend/V1_4__addgeocoordinnates.sql
+++ b/persistence/src/main/resources/db/migration/databackend/V1_4__addgeocoordinnates.sql
@@ -1,2 +1,0 @@
-ALTER TABLE "point" ADD "longitude" Decimal(22,19);
-ALTER TABLE "point" ADD "latitude" Decimal(22,19);

--- a/rest/src/test/java/de/starwit/rest/acceptance/AnalyticsJobControllerAcceptanceTest.java
+++ b/rest/src/test/java/de/starwit/rest/acceptance/AnalyticsJobControllerAcceptanceTest.java
@@ -81,6 +81,7 @@ public class AnalyticsJobControllerAcceptanceTest extends AbstractControllerAcce
         AnalyticsJobEntity retrievedEntity = mapper.readValue(response.getContentAsString(), AnalyticsJobEntity.class);
         assertThat(retrievedEntity.getId()).isEqualTo(responseEntity.getId());
         assertThat(retrievedEntity.getName()).isEqualTo(entity.getName());
+        assertThat(retrievedEntity.getGeoReferenced()).isTrue();
         assertThat(retrievedEntity.getGeometryPoints().get(0).getX().doubleValue()).isEqualTo(0.1);
         assertThat(retrievedEntity.getGeometryPoints().get(0).getLatitude().doubleValue()).isEqualTo(52.1);
         assertThat(retrievedEntity.getGeometryPoints().get(0).getLongitude().doubleValue()).isEqualTo(10.2);

--- a/rest/src/test/java/de/starwit/rest/acceptance/AnalyticsJobControllerAcceptanceTest.java
+++ b/rest/src/test/java/de/starwit/rest/acceptance/AnalyticsJobControllerAcceptanceTest.java
@@ -82,6 +82,8 @@ public class AnalyticsJobControllerAcceptanceTest extends AbstractControllerAcce
         assertThat(retrievedEntity.getId()).isEqualTo(responseEntity.getId());
         assertThat(retrievedEntity.getName()).isEqualTo(entity.getName());
         assertThat(retrievedEntity.getGeometryPoints().get(0).getX().doubleValue()).isEqualTo(0.1);
+        assertThat(retrievedEntity.getGeometryPoints().get(0).getLatitude().doubleValue()).isEqualTo(52.1);
+        assertThat(retrievedEntity.getGeometryPoints().get(0).getLongitude().doubleValue()).isEqualTo(10.2);
         assertThat(retrievedEntity.getGeometryPoints().get(1).getX().doubleValue()).isEqualTo(0.9);
     }
 

--- a/rest/src/test/resources/testdata/analytics-job/job1.json
+++ b/rest/src/test/resources/testdata/analytics-job/job1.json
@@ -9,12 +9,16 @@
 		{
 			"x": 0.1,
 			"y": 0.1,
-			"orderIdx": 0
+			"orderIdx": 0,
+			"latitude": 52.1,
+			"longitude": 10.2
 		},
 		{
 			"x": 0.9,
 			"y": 0.9,
-			"orderIdx": 1
+			"orderIdx": 1,
+			"latitude": 52.2,
+			"longitude": 10.1
 		}
 	]
 }

--- a/rest/src/test/resources/testdata/analytics-job/job1.json
+++ b/rest/src/test/resources/testdata/analytics-job/job1.json
@@ -5,6 +5,8 @@
 	"detectionClassId": 2,
 	"type": "LINE_CROSSING",
 	"enabled": false,
+	"geoReferenced": true,
+	"classification": "Lichtschranke",
 	"geometryPoints": [
 		{
 			"x": 0.1,

--- a/service/src/main/java/de/starwit/service/databackend/AnalyticsJobService.java
+++ b/service/src/main/java/de/starwit/service/databackend/AnalyticsJobService.java
@@ -59,6 +59,10 @@ public class AnalyticsJobService {
         existingJob.setParkingAreaId(jobUpdate.getParkingAreaId());
         existingJob.setType(jobUpdate.getType());
         existingJob.setEnabled(jobUpdate.getEnabled());
+        existingJob.setCameraId(jobUpdate.getCameraId());
+        existingJob.setClassification(jobUpdate.getClassification());
+        existingJob.setDetectionClassId(jobUpdate.getDetectionClassId());
+        existingJob.setGeoReferenced(jobUpdate.getGeoReferenced());
         existingJob.setGeometryPoints(jobUpdate.getGeometryPoints());
 
         AnalyticsJobEntity updatedJob = analyticsJobRepository.save(existingJob);

--- a/service/src/main/java/de/starwit/service/impl/ServiceInterface.java
+++ b/service/src/main/java/de/starwit/service/impl/ServiceInterface.java
@@ -6,7 +6,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import de.starwit.persistence.common.entity.AbstractEntity;
 import jakarta.persistence.EntityNotFoundException;
 
 /**

--- a/service/src/main/java/de/starwit/service/jobs/GeometryConverter.java
+++ b/service/src/main/java/de/starwit/service/jobs/GeometryConverter.java
@@ -1,0 +1,54 @@
+package de.starwit.service.jobs;
+
+import java.awt.geom.Area;
+import java.awt.geom.Line2D;
+import java.awt.geom.Path2D;
+import java.awt.geom.Point2D;
+
+import de.starwit.persistence.databackend.entity.AnalyticsJobEntity;
+import de.starwit.persistence.databackend.entity.PointEntity;
+import de.starwit.persistence.sae.entity.SaeDetectionEntity;
+
+public class GeometryConverter {
+    public static Area areaFrom(AnalyticsJobEntity jobConfig) {
+        Path2D.Double path = new Path2D.Double();
+        Point2D firstPoint = fromPoint(jobConfig.getGeometryPoints().get(0), jobConfig.getGeoReferenced());
+        path.moveTo(firstPoint.getX(), firstPoint.getY());
+
+        for (int i = 1;i < jobConfig.getGeometryPoints().size(); i++) {
+            Point2D point = fromPoint(jobConfig.getGeometryPoints().get(i), jobConfig.getGeoReferenced());
+            path.lineTo(point.getX(), point.getY());
+        }
+        
+        return new Area(path);
+    }
+
+    public static Line2D lineFrom(AnalyticsJobEntity jobConfig) {
+        Point2D pt1, pt2;
+        
+        pt1 = fromPoint(jobConfig.getGeometryPoints().get(0), jobConfig.getGeoReferenced());
+        pt2 = fromPoint(jobConfig.getGeometryPoints().get(1), jobConfig.getGeoReferenced());
+
+        return new Line2D.Double(pt1, pt2);
+    }
+
+    public static Point2D toCenterPoint(SaeDetectionEntity detection, boolean isGeo) {
+        double centerX, centerY;
+        if (isGeo) {
+            centerX = detection.getLongitude();
+            centerY = detection.getLatitude();
+        } else {
+            centerX = (detection.getMaxX() + detection.getMinX()) / 2;
+            centerY = (detection.getMaxY() + detection.getMinY()) / 2;
+        }
+        return new Point2D.Double(centerX, centerY);
+    }
+
+    public static Point2D fromPoint(PointEntity entity, boolean isGeo) {
+        if (isGeo) {
+            return new Point2D.Double(entity.getLongitude().doubleValue(), entity.getLatitude().doubleValue());
+        } else {
+            return new Point2D.Double(entity.getX().doubleValue(), entity.getY().doubleValue());
+        }
+    }
+}

--- a/service/src/test/java/de/starwit/service/jobs/AreaOccupancyJobTest.java
+++ b/service/src/test/java/de/starwit/service/jobs/AreaOccupancyJobTest.java
@@ -78,6 +78,7 @@ public class AreaOccupancyJobTest {
             Helper.createPoint(0, 100)
         ));
         entity.setType(JobType.AREA_OCCUPANCY);
+        entity.setGeoReferenced(false);
 
         return entity;
     }

--- a/service/src/test/java/de/starwit/service/jobs/Helper.java
+++ b/service/src/test/java/de/starwit/service/jobs/Helper.java
@@ -3,10 +3,7 @@ package de.starwit.service.jobs;
 import java.awt.geom.Point2D;
 import java.math.BigDecimal;
 import java.time.Instant;
-import java.util.Arrays;
 
-import de.starwit.persistence.databackend.entity.AnalyticsJobEntity;
-import de.starwit.persistence.databackend.entity.JobType;
 import de.starwit.persistence.databackend.entity.PointEntity;
 import de.starwit.persistence.sae.entity.SaeDetectionEntity;
 

--- a/service/src/test/java/de/starwit/service/jobs/LineCrossingJobTest.java
+++ b/service/src/test/java/de/starwit/service/jobs/LineCrossingJobTest.java
@@ -66,6 +66,7 @@ public class LineCrossingJobTest {
             Helper.createPoint(100, 100)
         ));
         entity.setType(JobType.LINE_CROSSING);
+        entity.setGeoReferenced(false);
 
         return entity;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
**Important: This branches off of AB#1069, so we should merge #25 first.**

## Description
<!--- Describe your changes in detail -->
Makes the databackend capable of working with geo coordinates end-to-end:
- Get geo-coordinates from database (add to `SaeDetectionEntity`
- Make algorithms aware of geo-coordinates and the existance of the `geoReferenced` flag (this part could probably be a bit more elegant, I'll happily take feedback on that :slightly_smiling_face:)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The API is tested by the corresponding test suite. End-to-end was tested manually (until we have a good solution).
Testing the algorithms with `geoReferenced == true` is probably not bringing much value to this project, as the algorithms only need coordinates within an euclidean space to work with, so the algorithms themselves have not been changed at all. Therefore, I did not add tests for that.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
