### PR TITLE
Fix wrong crossing direction when running on geo-coordinates

### DIFF
--- a/service/src/main/java/de/starwit/service/jobs/GeometryConverter.java
+++ b/service/src/main/java/de/starwit/service/jobs/GeometryConverter.java
@@ -57,7 +57,9 @@ public class GeometryConverter {
         double centerX, centerY;
         if (isGeo) {
             centerX = detection.getLongitude();
-            centerY = detection.getLatitude();
+            // Geo coordinate system has y-axis flipped upside down (compared to image coordinate system)
+            // therefore we need to reverse the latitude sign to make everything consistent.
+            centerY = -detection.getLatitude();
         } else {
             centerX = (detection.getMaxX() + detection.getMinX()) / 2;
             centerY = (detection.getMaxY() + detection.getMinY()) / 2;
@@ -67,7 +69,8 @@ public class GeometryConverter {
 
     public static Point2D fromPoint(PointEntity entity, boolean isGeo) {
         if (isGeo) {
-            return new Point2D.Double(entity.getLongitude().doubleValue(), entity.getLatitude().doubleValue());
+            // See comment in toCenterPoint()
+            return new Point2D.Double(entity.getLongitude().doubleValue(), -entity.getLatitude().doubleValue());
         } else {
             return new Point2D.Double(entity.getX().doubleValue(), entity.getY().doubleValue());
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Transparently flip y-axis for algorithms when using geo-coordinates, as the coordinate systems for image and geo have oppositely oriented y-axis. This has the benefit of the line-crossing algorithm yielding consistent crossing directions with both geo and image coordinates.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
