### PR TITLE
Fix trajectory purging using now() as a reference, instead use the last seen detection

### DIFF
--- a/service/src/main/java/de/starwit/service/jobs/LineCrossingJob.java
+++ b/service/src/main/java/de/starwit/service/jobs/LineCrossingJob.java
@@ -41,7 +41,7 @@ public class LineCrossingJob extends AbstractJob {
             }
         }
 
-        trajectoryStore.purge(Duration.ofSeconds(5));
+        trajectoryStore.purge(dto.getCaptureTs());
     }
     
     private void trimTrajectory(SaeDetectionDto det) {

--- a/service/src/main/java/de/starwit/service/jobs/ObservationJobRunner.java
+++ b/service/src/main/java/de/starwit/service/jobs/ObservationJobRunner.java
@@ -2,8 +2,6 @@ package de.starwit.service.jobs;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -89,9 +87,9 @@ public class ObservationJobRunner {
             activeSubscriptions.add(redisSubscription);
         }
 
-        streamListenerContainer.start();        
+        streamListenerContainer.start();
     }
-            
+
     @Scheduled(fixedDelay = 500, timeUnit = TimeUnit.MILLISECONDS)
     public void feedJobs() {
         List<SaeDetectionDto> newDtos = saeMessageListener.getBufferedMessages();

--- a/service/src/main/java/de/starwit/service/jobs/TrajectoryStore.java
+++ b/service/src/main/java/de/starwit/service/jobs/TrajectoryStore.java
@@ -59,9 +59,13 @@ public class TrajectoryStore {
         }
     }
 
-    public void purge(Duration maxAge) {
+    /**
+     * Purges all trajectories that have not been updated since the given time minus 60 seconds.
+     * @param latestTimestamp
+     */
+    public void purge(Instant latestTimestamp) {
         List<String> keysToDelete = new ArrayList<>();
-        Instant cutOff = Instant.now().minus(maxAge);
+        Instant cutOff = latestTimestamp.minus(Duration.ofSeconds(60));
         for (Entry<String, LinkedList<SaeDetectionDto>> entry: trajectoryByObjId.entrySet()) {
             if (entry.getValue().isEmpty() || entry.getValue().getLast().getCaptureTs().isBefore(cutOff)) {
                 keysToDelete.add(entry.getKey());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `TrajectoryStore` is used to piece together object trajectories and hold them as a part of observation job state. In order to avoid a memory leak, trajectories have to be purged regularly based on the actuality of the tracks (i.e. the trajectory of an object that has not been seen for some time can be removed safely).
The original implementation used the current time as a reference to delete all trajectories older than a certain duration. Because in the real deployment there is an issue with latency (i.e. databackend gets data that is already a minute or so old), too many trajectories were removed. 
The new implementation changes that and uses the last seen time (minus an offset of 60s) as reference for purging.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
