### PR TITLE
Switch Redis driver to Lettuce for better reconnect handling

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -51,9 +51,9 @@
             <version>2.0.1</version>
         </dependency>
         <dependency>
-            <groupId>redis.clients</groupId>
-            <artifactId>jedis</artifactId>
-            <version>5.0.2</version>
+            <groupId>io.lettuce</groupId>
+            <artifactId>lettuce-core</artifactId>
+            <version>6.3.2.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>de.grundid.opendatalab</groupId>

--- a/service/src/main/java/de/starwit/service/jobs/ObservationJobRunner.java
+++ b/service/src/main/java/de/starwit/service/jobs/ObservationJobRunner.java
@@ -21,8 +21,6 @@ import de.starwit.persistence.databackend.entity.ObservationJobEntity;
 import de.starwit.service.analytics.AreaOccupancyService;
 import de.starwit.service.analytics.LineCrossingService;
 import de.starwit.service.databackend.ObservationJobService;
-import de.starwit.service.geojson.GeoJsonMapper;
-import de.starwit.service.geojson.GeoJsonSenderService;
 import de.starwit.service.geojson.GeoJsonService;
 import de.starwit.service.sae.SaeDetectionDto;
 import de.starwit.service.sae.SaeMessageListener;

--- a/service/src/main/java/de/starwit/service/sae/RedisConfiguration.java
+++ b/service/src/main/java/de/starwit/service/sae/RedisConfiguration.java
@@ -1,11 +1,13 @@
 package de.starwit.service.sae;
 
+import java.time.Duration;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.stream.StreamMessageListenerContainer;
 
@@ -20,12 +22,14 @@ public class RedisConfiguration {
     
     @Bean
     StreamMessageListenerContainer<String, MapRecord<String, String, String>> streamMessageListenerContainer() {
-        return StreamMessageListenerContainer.create(redisConnectionFactory());
+        return StreamMessageListenerContainer.create(lettuceConnectionFactory());
     }
 
     @Bean
-    RedisConnectionFactory redisConnectionFactory() {
-        return new JedisConnectionFactory(new RedisStandaloneConfiguration(redisHost, redisPort));
+    LettuceConnectionFactory lettuceConnectionFactory() {
+        return new LettuceConnectionFactory(
+            new RedisStandaloneConfiguration(redisHost, redisPort), 
+            LettuceClientConfiguration.builder().commandTimeout(Duration.ofDays(9999)).build());
     }
     
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
After a lot of research in the documentation and experimenting, I found the best solution for having a robust auto-reconnect for the Redis connection is to use the Lettuce client (which explicitly supports auto-reconnect with some sort of exponential backoff) and set the command timeout to a very large timespan.
If the command timeout expires, than the reconnect mechanism is circumvented by handing the control back to the Spring Data Redis implementation, which invalidates the Redis subscription. Preventing that is not an option, as the Spring Data layer apparently does not have a backoff delay, so it'll go into a busy loop and try to reconnect indefinitely, which increases system load unnecessarily.
The large command timeout is basically a hack to force the driver layer to continiously handle reconnection.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
