### PR TITLE
add intervall to 5 second sliding window, such that window is analyze…

### DIFF
--- a/service/src/main/java/de/starwit/service/jobs/AreaOccupancyJob.java
+++ b/service/src/main/java/de/starwit/service/jobs/AreaOccupancyJob.java
@@ -28,10 +28,11 @@ public class AreaOccupancyJob extends AbstractJob {
     @Override
     protected void processNewDetection(SaeDetectionDto dto) {
         addDataToSlidingWindow(dto);
-        if (slidingWindowLength().toMillis() < SLIDING_WINDOW_TARGET_LENGTH.toMillis()) {
+        //log.info(slidingWindowLength().toMillis() + " < " + SLIDING_WINDOW_TARGET_LENGTH.toMillis());
+        if (slidingWindowLength().toMillis() < SLIDING_WINDOW_TARGET_LENGTH.toMillis() - 150) {
             return;
         }
-
+        
         Map<Long, List<SaeDetectionDto>> detByCaptureTs = this.slidingWindow.stream().collect(Collectors.groupingBy(det -> det.getCaptureTs().toEpochMilli()));
     
         Area polygon = GeometryConverter.areaFrom(this.configEntity);


### PR DESCRIPTION
5 second threshold for area occupancy analysis is never reached, when many messages are received. Fix is a 150 ms intervall, such that window size in terms of time is reached.

## Motivation and Context
If window never becomes large enough, area occupancy is not calculated.

## How has this been tested?
Fix is minimal, all unit tests run as expected.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
